### PR TITLE
Fixed agent navbar options showing up on non-agent accounts.

### DIFF
--- a/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
+++ b/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
@@ -4,7 +4,8 @@ export function storeUserInfo(userInfo) {
     window.localStorage.setItem('Token', userInfo.token);
     window.localStorage.setItem('UserId', userInfo.userId);
     window.localStorage.setItem('Admin', userInfo.isAdmin ? 'true' : 'false');
-    window.localStorage.setItem('Agent', userInfo.agentId >= 0 ? 'true' : 'false');
+    window.localStorage.setItem('AgentId', userInfo.agentId >= 0 ? 'true' : 'false');
+    window.localStorage.setItem('isAgent', userInfo.agentId == null ? 'false' : 'true');
 
     updateListeners();
 }
@@ -13,7 +14,8 @@ export function clearUserInfo() {
     window.localStorage.clear('Token');
     window.localStorage.clear('UserId');
     window.localStorage.clear('Admin');
-    window.localStorage.clear('Agent');
+    window.localStorage.clear('AgentId');
+    window.localStorage.clear('isAgent');
 
     updateListeners();
 }
@@ -35,7 +37,7 @@ export function isAdmin(){
 }
 
 export function isAgent() {
-    return window.localStorage.getItem('Agent') === 'true';
+    return window.localStorage.getItem('isAgent') === 'true';
 }
 
 // Fire a 'login' event when the user info is updated.

--- a/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
+++ b/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
@@ -4,7 +4,7 @@ export function storeUserInfo(userInfo) {
     window.localStorage.setItem('Token', userInfo.token);
     window.localStorage.setItem('UserId', userInfo.userId);
     window.localStorage.setItem('Admin', userInfo.isAdmin ? 'true' : 'false');
-    window.localStorage.setItem('AgentId', userInfo.agentId >= 0 ? 'true' : 'false');
+    window.localStorage.setItem('AgentId', userInfo.agentId);
 
     updateListeners();
 }

--- a/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
+++ b/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
@@ -5,7 +5,6 @@ export function storeUserInfo(userInfo) {
     window.localStorage.setItem('UserId', userInfo.userId);
     window.localStorage.setItem('Admin', userInfo.isAdmin ? 'true' : 'false');
     window.localStorage.setItem('AgentId', userInfo.agentId >= 0 ? 'true' : 'false');
-    window.localStorage.setItem('isAgent', userInfo.agentId == null ? 'false' : 'true');
 
     updateListeners();
 }
@@ -15,7 +14,6 @@ export function clearUserInfo() {
     window.localStorage.clear('UserId');
     window.localStorage.clear('Admin');
     window.localStorage.clear('AgentId');
-    window.localStorage.clear('isAgent');
 
     updateListeners();
 }
@@ -37,7 +35,7 @@ export function isAdmin(){
 }
 
 export function isAgent() {
-    return window.localStorage.getItem('isAgent') === 'true';
+    return window.localStorage.getItem('AgentId') != null;
 }
 
 // Fire a 'login' event when the user info is updated.

--- a/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
+++ b/AgentDiscoveries-Frontend/app/src/components/utilities/user-helper.js
@@ -35,7 +35,7 @@ export function isAdmin(){
 }
 
 export function isAgent() {
-    return window.localStorage.getItem('AgentId') != null;
+    return window.localStorage.getItem('AgentId') !== null;
 }
 
 // Fire a 'login' event when the user info is updated.


### PR DESCRIPTION
The user-helper code was set up so that "Agent" was set to true if the agentID was greater than or equal to 0. Since userInfo is populated with data pulled from the database, this doesn't work because agentId can be null in the database.

I added a new localStorage property- "isAgent", which is set to 'true' or 'false' (strings, not booleans) depending on whether or not "agentID" (formerly "agent") is null or not. Since any user with a non-null agent ID will always be an agent.

I've also modified clearUserInfo to properly clear AgentId and isAgent, and changed the isAgent (function)'s return statement to reference the isAgent variable rather than the now non-existent Agent variable.